### PR TITLE
Build image on release

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,47 @@
+name: Build image
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  build_and_push:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/MapTheMesh/meshtastic-node-transmit-client:latest
+            ghcr.io/MapTheMesh/meshtastic-node-transmit-client:${{ github.ref_name }}
+          labels: |
+            org.opencontainers.image.title=Map The Mesh Runner
+            org.opencontainers.image.description=Docker image for Cloudlog
+            org.opencontainers.image.url=https://github.com/MapTheMesh/meshtastic-node-transmit-client/pkgs/container/meshtastic-node-transmit-client/
+


### PR DESCRIPTION
* Build new docker image when release is tagged.
* Uses GitHub packages but can hook up to Docker Hub if preferred.
* Will build `linux/amd64` and `linux/arm64` images.